### PR TITLE
Added working nav weights

### DIFF
--- a/docnado/docnado.py
+++ b/docnado/docnado.py
@@ -45,6 +45,8 @@ from markdown.postprocessors import Postprocessor
 from markdown.inlinepatterns import LinkPattern, IMAGE_LINK_RE, dequote, handleAttributes
 from markdown.blockprocessors import HashHeaderProcessor
 
+from navtree import NavItem, parse_nav_string
+
 
 class MultiPurposeLinkPattern(LinkPattern):
     """ Embed image, video, youtube, csv or file download links
@@ -360,22 +362,38 @@ def build_meta_cache(root):
 
 
 def build_nav_menu(meta_cache):
-    """ Given a cache of Markdown `Meta` data, compile a structure that can be
-    used to generate the NAV menu.
-    This uses the `nav: Assembly>Bench>Part` variable at the top of the Markdown file.
-    """
-    tree = collections.UserDict()
-    for url, meta in meta_cache.items():
-        # Get the NAV strings from the metadata.
-        navgroup = meta.get('nav', [])
-        for navstr in navgroup:
-            t = tree
-            for part in navstr.split('>'):
-                t = t.setdefault(part, collections.UserDict())
-            t.meta = meta
-            t.link = url
-    return tree
+    # """ Given a cache of Markdown `Meta` data, compile a structure that can be
+    # used to generate the NAV menu.
+    # This uses the `nav: Assembly>Bench>Part` variable at the top of the Markdown file.
+    # """
+    # tree = collections.UserDict()
+    # for url, meta in meta_cache.items():
+    #     # Get the NAV strings from the metadata.
+    #     navgroup = meta.get('nav', [])
+    #     for navstr in navgroup:
+    #         t = tree
+    #         for part in navstr.split('>'):
+    #             t = t.setdefault(part, collections.UserDict())
+    #         t.meta = meta
+    #         t.link = url
+    # return tree
+    root = NavItem('root', 0)
+    for path, meta in meta_cache.items():
+        nav_str = meta.get('nav', [None])[0]
+        nav_chunks = parse_nav_string(nav_str)
 
+
+
+        node = root
+        for name, weight in nav_chunks:
+            n = NavItem(name, weight)
+            node = node.add(n)
+
+        node.meta = meta
+        node.link = path
+
+    root.arrange()
+    return root
 
 def build_reload_files_list(extra_dirs=[]):
     """ Given a list of directories, return a list of files to watch for modification

--- a/docnado/docs/contributing/development.md
+++ b/docnado/docs/contributing/development.md
@@ -3,7 +3,7 @@ desc:       Docnado Tooling Quick Reference
 date:       2018/07/20
 version:    1.0.0
 template:   document
-nav:        Contributing>Development
+nav:        Contributing __4__>Development
 percent:    100
 authors:    enq@heinventions.com
 

--- a/docnado/docs/documents/callouts.md
+++ b/docnado/docs/documents/callouts.md
@@ -3,7 +3,7 @@ desc:       Docnado Markdown Quick Reference
 date:       2018/10/12
 version:    1.0.0
 template:   document
-nav:        Document>Callouts
+nav:        Document __2__>Callouts
 percent:    100
 authors:    enq@heinventions.com
 

--- a/docnado/docs/home.md
+++ b/docnado/docs/home.md
@@ -3,7 +3,7 @@ desc:       Rapid documentation tool to blow you away.
 date:       2018/08/05
 version:    1.0.0
 template:   document
-nav:        Home
+nav:        Home __-1__
 percent:    100
 authors:    enq@heinventions.com
 

--- a/docnado/docs/setup/installation.md
+++ b/docnado/docs/setup/installation.md
@@ -3,7 +3,7 @@ desc:       The official docnado installation guide.
 date:       2018/10/11
 version:    1.0.0
 template:   document
-nav:        Get Setup>Installation
+nav:        Get Setup __1__>Installation
 percent:    100
 authors:    enq@heinventions.com
 

--- a/docnado/docs/setup/meta-data.md
+++ b/docnado/docs/setup/meta-data.md
@@ -39,7 +39,7 @@ template
 : Says which `HTML` page should be used to render the content. You can make your own `HTML` templates for different styles of documentation.
 
 nav
-: Defines where the document should appear in the menu structure. For instance `Folder A>Folder B>Doc Name` would put our document inside `Folder B` which is inside `Folder A`. These directories are artificial and you can put in whatever makes sense.
+: Defines where the document should appear in the menu structure. For instance `Folder A>Folder B>Doc Name` would put our document inside `Folder B` which is inside `Folder A`. These directories are artificial and you can put in whatever makes sense. You can also use `Folder A __99__>Folder B __-1__>Doc Name __12__` to apply weights that order the nav menu.
 
 percent
 : Is a number between `0` and `100`. If this is left out or is set to `100` then nothing happens. However, if you are working on a document then setting this will put a progress bar in the document header.

--- a/docnado/docs/tooling/broken_links.md
+++ b/docnado/docs/tooling/broken_links.md
@@ -3,7 +3,7 @@ desc:       Docnado Tooling Quick Reference
 date:       2018/07/20
 version:    1.0.0
 template:   document
-nav:        Tooling>Broken Links
+nav:        Tooling __3__>Broken Links
 percent:    100
 authors:    enq@heinventions.com
 

--- a/docnado/navtree.py
+++ b/docnado/navtree.py
@@ -1,0 +1,130 @@
+""" Navigation Tree for docnado
+
+python -m doctest .\navtree.py
+"""
+
+import os
+import re
+
+def parse_nav_string(nav):
+    """ Parse a nav string and pull out the `name` and `weight` of each nav item.
+
+    >>> parse_nav_string('Foo>Bar>Baz')
+    [('Foo', 0), ('Bar', 0), ('Baz', 0)]
+
+    >>> parse_nav_string('Foo __99__>Bar>Baz')
+    [('Foo', 99.0), ('Bar', 0), ('Baz', 0)]
+
+    >>> parse_nav_string('Foo __-1__>Bar>Baz')
+    [('Foo', -1.0), ('Bar', 0), ('Baz', 0)]
+
+    >>> parse_nav_string(None)
+    []
+    """
+    NAV_PARSER = r'\w+\s*__(-?\d+)__'
+    if not nav:
+        return []
+
+    def _weight(chunk):
+        matches = re.search(NAV_PARSER, chunk)
+        return float(matches.group(1)) if matches else 0
+
+    def _name(chunk):
+        return chunk.split('__')[0].strip()
+
+    chunks = [(_name(chunk), _weight(chunk)) for chunk in nav.split('>')]
+    return chunks
+
+
+class NavItem:
+    """ An item (either based on a document or not) that appears in the Nav menu.
+
+    >>> NavItem('root', 0).name
+    'root'
+
+    >>> NavItem('root', 0).weight
+    0
+    """
+
+    def __init__(self, name, weight):
+        self.name = name
+        self.weight = weight
+        self.children = []
+
+        self.meta = []
+
+    def items(self):
+        return [(child.name, child) for child in self.children]
+
+
+    def add(self, node):
+        """ Add a new child to this menu item. If a child with the same name already
+        exists then return that child. If a child with the same name does not
+        already exist, then add the item we pass in and return it.
+
+        >>> a = NavItem('root', 0)
+        >>> na = a.add(NavItem('A', 10))
+        >>> nb = a.add(NavItem('A', 15))
+        >>> nc = a.add(NavItem('C', 20))
+        >>> len(a.children) == 2
+        True
+        >>> na.weight == 10
+        True
+        >>> na in a.children
+        True
+        >>> nb == na
+        True
+        >>> nc in a.children
+        True
+        """
+        existing_children = []
+        for c in self.children:
+            if c.name == node.name:
+                if c.weight == 0:
+                    c.weight = node.weight
+
+                return c
+        self.children.append(node)
+        return node
+
+    def arrange(self):
+        """ Sort all the children of this node by their weight.  Then tell them
+        to sort themselves in turn.
+
+        >>> nav = NavItem("home", 0)
+        >>> n1 = nav.add(NavItem("A", 10))
+        >>> nav.children[0].name
+        'A'
+
+        >>> n2 = nav.add(NavItem("C", 30))
+        >>> nav.children[1].name
+        'C'
+
+        >>> n3 = nav.add(NavItem("B", 20))
+        >>> nav.arrange()
+        >>> nav.children[0].name
+        'A'
+        >>> nav.children[0].weight == 10
+        True
+
+        >>> nav.children[1].name
+        'B'
+        >>> nav.children[1].weight == 20
+        True
+
+        >>> nav.children[2].name
+        'C'
+        >>> nav.children[2].weight == 30
+        True
+        """
+        self.children.sort(key=lambda c: c.weight, reverse=False)
+        for c in self.children:
+            c.arrange()
+
+    def _debug(self, level=0):
+        """ Print out the data of this objcect to the console in a nicely formatted
+        output. Intended for debugging only.
+        """
+        print('  '*level, self.name, self.weight)
+        for c in self.children:
+            c.debug(level + 1)


### PR DESCRIPTION
`nav` defines where the document should appear in the menu structure. 

For instance `Folder A>Folder B>Doc Name` would put our document inside `Folder B` which is inside `Folder A`. 

These directories are artificial and you can put in whatever makes sense. 

You can also use `Folder A __99__>Folder B __-1__>Doc Name __12__` to apply weights that order the nav menu.

We have also split out the navigation tree logic into a separate file.

TODO:

* Doctests on `items()` function
* Add back in support for multiple `nav_str` in `build_nav_menu`
