### PR TITLE
Fix for relative import

### DIFF
--- a/docnado/docnado.py
+++ b/docnado/docnado.py
@@ -45,7 +45,7 @@ from markdown.postprocessors import Postprocessor
 from markdown.inlinepatterns import LinkPattern, IMAGE_LINK_RE, dequote, handleAttributes
 from markdown.blockprocessors import HashHeaderProcessor
 
-from navtree import NavItem, parse_nav_string
+from .navtree import NavItem, parse_nav_string
 
 
 class MultiPurposeLinkPattern(LinkPattern):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='docnado',
-    version='1.0.3',
+    version='1.0.4',
     author='Hardy & Ellis Inventions LTD',
     author_email='support@heinventions.com',
 


### PR DESCRIPTION
Closes #13 

Note that this means we get this:

```
Traceback (most recent call last):
  File ".\docnado.py", line 48, in <module>
    from .navtree import NavItem, parse_nav_string
ModuleNotFoundError: No module named '__main__.navtree'; '__main__' is not a package
``` 

When we try to run it from the command line as `__main__`