### PR TITLE
WIP: Pull multiple articles into a single document via a special URL route

### DIFF
--- a/docnado/style/templates/base.html
+++ b/docnado/style/templates/base.html
@@ -24,6 +24,7 @@
 </head>
     <body>
 
+        {% block headerbar %}
         <!-- Header Bar -->
         <header class="navbar navbar-light page-headbar">
             <button class="navbar-toggler page-togglesidebar" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
@@ -42,7 +43,9 @@
                 {% endif %}
             </nav>
         </header>
+        {% endblock %}
 
+        {% block sidebar %}
         <!-- Side Bar -->
         <aside class="page-sidebar">
 
@@ -108,6 +111,7 @@
             {% block sidebar_foot %}
             {% endblock %}
         </aside>
+        {% endblock %}
 
         <!-- MAIN PAGE CONTENT -->
         <section class="page-main">

--- a/docnado/style/templates/book.html
+++ b/docnado/style/templates/book.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+
+{% block title %}
+    <title>{{ title | first }}</title>
+{% endblock %}
+
+
+{% block sidebar %}
+<!-- Side Bar -->
+<aside class="page-sidebar">
+
+    {% block sidebar_head %}
+    {% endblock %}
+    .
+    <ul class="tree-nav tree-root">
+        {%- for section in sections %}
+        <li class="tree-leaf">
+            <i class="fa fa-circle-thin" aria-hidden="true"></i>
+            <a href="#{{ section.page | safe_css_id }}"><span>{{ section.meta.title | first }}</span></a>
+        </li>
+        {%- endfor %}
+    </ul>
+
+    {% block sidebar_foot %}
+    {% endblock %}
+</aside>
+{% endblock %}
+
+
+
+{% block content %}
+
+    <!-- {{ report.pages }} -->
+    <script type="text/javascript">
+
+    // Fix the gravatar icon if the gravatar fails to load.
+    $('.page-header img.avatar').on('error', function(){
+        let avatar = $(this);
+        avatar.attr('src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMTZEaa/1AAACCElEQVRIS+2VO0sDQRSFE/ARX62CFprCThTNc9OkCqaINhLQKqiQ1ohN0CJgZaGFxD+iELG0EX+CoL2FIFFBLOM55mCVNTM7sRD84LJzz9x7dvY1G/qnG8lkMorYjsfjhwyMt6hpuvfgJHOIq1gs9oo4x/iYwTE1zrFG5b0BV7QB8yaM97PZ7Kjkb6hxjjWpVGpdshuJRCIPw2ecPC3JF9awlj2SgpHJZMZwJY+IFUldYS172CvJHlzBLq7gUqkx7GGvUntgcIPVryk1hj3sVWoPDN5xyyaVGpNOp6fYq9SOfD4/iFW38MZGJBlTKpUi7C0WiwOS7OCquXqlxjhdMeFzwndp/YzZ4/SM0Rz4rWavUnsCfser7HH6jgl2oWWs3mjnQq3HWvZIcgNGVRh+4Hjgt1dzTjVVyW7gtlVgyL/PKaLBMeIC4xMGx5pvIOoYv+FYUXsgwlj9GYzu8ZbOS+MbOwPjTcTX/5hjz/OmNc1tdgE9D+xFGm6rFvDWwfQOpuOSjMHiJthLD0lmoCGOVfPfOivJGvbSg16SuoOGazTsKQ0MPeil9GdwaxdR/IRtb0hSYOghryVJ/uDZHCHqSp2hFz2V+oOiW4TxTtUNetFTqT8oeuEno9QZfF5ReDaVdqZcLvfjmbQKhcKwJGdyudwIPWu1Wp+kjoSxuh0e22lP+A3PP0co9AlOca7xK4NYXAAAAABJRU5ErkJggg==');
+    });
+
+    </script>
+
+    {%- for section in sections %}
+
+        <section class="article-main">
+
+            {% if section.meta.title is defined %}
+            <div class="page-header">
+                <h1 id="{{ section.page | safe_css_id }}" class="display-4">{{ section.meta.title | first }}</h1>
+                <p class="lead">{{ section.meta.desc | first }}</p>
+                <p>
+                    {% if versions == "1" %}
+                    <span class="version">V{{ section.meta.version | first }}</span>
+                    {% endif %}
+
+                    {% if authors %}
+                    {% for email in section.meta.authors %}
+                    <img src="{{ email | gravatar }}" class="avatar" alt="{{ email }}" title="{{ email }}" />
+                    {% endfor %}
+                    {% endif %}
+
+                    {% if dates %}
+                    <small><span>{{ section.meta.date | first }}</span></small>
+                    {% endif %}
+                </p>
+
+                {% if section.meta.percent and section.meta.percent != ['100'] %}
+                    <hr class="my-4">
+                    <p>This section is approximately {{ section.meta.percent | first }}% complete.
+                        <div class="progress">
+                          <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width:  {{ percent | first }}%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </p>
+                {% endif %}
+            </div>
+            <br/>
+            {% endif %}
+
+            <div class="page-md">
+                {{ section.content }}
+            </div>
+        </section>
+
+
+    {%- endfor %}
+{% endblock %}
+
+{% block script %}
+<script type="text/javascript">
+
+    $(document).ready(function() {
+
+        // // Apply CSS specific to a table in a *parts* heading.
+        // $('.page-md #parts + table')
+        //     .addClass('parts')
+        // //     .addClass('table thead-light table-hover')
+        // //     //.css('position', 'absolute')
+        //     //.css('width', '60%');
+    });
+
+</script>
+{% endblock %}

--- a/docnado/style/templates/document.html
+++ b/docnado/style/templates/document.html
@@ -40,6 +40,12 @@
 {% block script %}
 <script type="text/javascript">
 
+    // Fix the gravatar icon if the gravatar fails to load.
+    $('.page-header img.avatar').on('error', function(){
+        let avatar = $(this);
+        avatar.attr('src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMTZEaa/1AAACCElEQVRIS+2VO0sDQRSFE/ARX62CFprCThTNc9OkCqaINhLQKqiQ1ohN0CJgZaGFxD+iELG0EX+CoL2FIFFBLOM55mCVNTM7sRD84LJzz9x7dvY1G/qnG8lkMorYjsfjhwyMt6hpuvfgJHOIq1gs9oo4x/iYwTE1zrFG5b0BV7QB8yaM97PZ7Kjkb6hxjjWpVGpdshuJRCIPw2ecPC3JF9awlj2SgpHJZMZwJY+IFUldYS172CvJHlzBLq7gUqkx7GGvUntgcIPVryk1hj3sVWoPDN5xyyaVGpNOp6fYq9SOfD4/iFW38MZGJBlTKpUi7C0WiwOS7OCquXqlxjhdMeFzwndp/YzZ4/SM0Rz4rWavUnsCfser7HH6jgl2oWWs3mjnQq3HWvZIcgNGVRh+4Hjgt1dzTjVVyW7gtlVgyL/PKaLBMeIC4xMGx5pvIOoYv+FYUXsgwlj9GYzu8ZbOS+MbOwPjTcTX/5hjz/OmNc1tdgE9D+xFGm6rFvDWwfQOpuOSjMHiJthLD0lmoCGOVfPfOivJGvbSg16SuoOGazTsKQ0MPeil9GdwaxdR/IRtb0hSYOghryVJ/uDZHCHqSp2hFz2V+oOiW4TxTtUNetFTqT8oeuEno9QZfF5ReDaVdqZcLvfjmbQKhcKwJGdyudwIPWu1Wp+kjoSxuh0e22lP+A3PP0co9AlOca7xK4NYXAAAAABJRU5ErkJggg==');
+    });
+
     $(document).ready(function() {
 
         // // Apply CSS specific to a table in a *parts* heading.


### PR DESCRIPTION
We have needed a couple of times to pull multiple articles into a single document.   We did this previously by exporting all the relevant PDFs, and then concatenating them together.   This sucked because it was slow and unweidly.

This PR adds a special URL `http://localhost:5000/book/?page=setup/installation.md&page=setup/meta-data.md#setup_meta_data_md&authors=true&versions=1` that lets users specify ordered pages (via URL args or request body).  This can be used to automatically generate reports / books.

Limitations:

Only applies the default "document" style via "book.html" template.

Todo before merge:

* [ ] Code quality
* [ ] Example script / documentation for how to create a book
* [ ] Table of contents / page numbering?
* [ ] Page Breaks